### PR TITLE
Fix GitHub profile link in contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
             <li>Email: raflii.works@gmail.com</li>
             <li>Phone: +62 813-9643-6609</li>
             <li>LinkedIn: <a href="https://www.linkedin.com/in/ahmad-rafli-harahap-a88105299?utm_source=share&utm_campaign=share_via&utm_content=profile&utm_medium=android_app" target="_blank">linkedin.com/in/ahmadrafliharahap</a></li>
-            <li>Github: <a href="https://github.com/ahmadrafli02" target="_blank">github.com/in/ahmadrafli02</a></li>
+            <li>Github: <a href="https://github.com/ahmadrafli02" target="_blank">github.com/ahmadrafli02</a></li>
         </ul>
     </section>
     <footer>


### PR DESCRIPTION
## Summary
- correct GitHub contact link text to match actual profile URL

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ab54e9120832aa7b269d234c61af1